### PR TITLE
在门店列表中添加排序

### DIFF
--- a/services/store.go
+++ b/services/store.go
@@ -5,6 +5,7 @@ import (
 	"github.com/parnurzeal/gorequest"
 	"github.com/thoas/go-funk"
 	"github.com/tidwall/gjson"
+	"sort"
 )
 
 var Store = storeService{
@@ -40,7 +41,9 @@ func (s *storeService) ByAreaCode(areaCode string) []model.Store {
 
 func (s *storeService) ByAreaTitleForOptions(areaTitle string) []string {
 	code := Area.Title2Code(areaTitle)
-	return funk.Get(s.ByAreaCode(code), "CityStoreName").([]string)
+	areas := funk.Get(s.ByAreaCode(code), "CityStoreName").([]string)
+	sort.Strings(areas)
+	return areas
 }
 
 func (s *storeService) GetStore(areaTitle string, storeTitle string) model.Store {


### PR DESCRIPTION
在使用时发现门店清单获取是无序的, 如果我在某个城市想要勾选全部门店就要来回滚动比较麻烦. 所以在获取门店信息的时候加上了一个排序函数.

排序前:
![image](https://user-images.githubusercontent.com/30694270/134725190-8afc995e-0650-4d25-a88f-5b9f60f8394c.png)

排序后:
![image](https://user-images.githubusercontent.com/30694270/134725261-122565e8-e990-4d62-8859-cd19073650a9.png)
