### PR TITLE
Fix downloading go1.22 Error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module apple-store-helper
 
-go 1.22
+go 1.22.0
 
 require (
 	fyne.io/fyne/v2 v2.5.1


### PR DESCRIPTION
$ go run main.go
go: downloading go1.22 (darwin/arm64)
go: download go1.22 for darwin/arm64: toolchain not available

Update go.mod
-go 1.22
+go 1.22.0