### PR TITLE
Fix: Resolve gorequest 503 Service Unavailable Error

### DIFF
--- a/services/listen.go
+++ b/services/listen.go
@@ -219,9 +219,10 @@ func (s *listenService) getSkuByLink(ch chan map[string]bool, skUrl string) {
 	skus := map[string]bool{}
 
 	resp, body, errs := gorequest.New().
+		Get(skUrl).
 		Set("referer", "https://www.apple.com/shop/buy-iphone").
 		Set("user-agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.71 Safari/537.36").
-		Timeout(time.Second * 3).Get(skUrl).End()
+		Timeout(time.Second * 3).End()
 	if len(errs) > 0 {
 		log.Println(errs)
 		ch <- skus


### PR DESCRIPTION
The application was encountering 503 Service Unavailable errors when making HTTP requests, due to improper request method chaining in the gorequest library.

Fixed method chaining order